### PR TITLE
remove potential false sharing on counters

### DIFF
--- a/test/integration/counter.h
+++ b/test/integration/counter.h
@@ -1,0 +1,49 @@
+#ifndef _INPUTOSMTESTCOUNTER_H_
+#define _INPUTOSMTESTCOUNTER_H_
+
+#include <cstdint>
+
+namespace input_osm
+{
+
+// since each thread works on one uint64, let's make sure these are not false-shared
+template <typename T>
+// T should be an integer type (like uint64_t, int32_t, etc...)
+struct Counter
+{
+    static_assert(sizeof(T) < 64);
+
+    Counter() = default;
+
+    Counter(T c): count(c) {}
+
+    // to simplify using the algorithms with this type
+    operator const T&() const
+    {
+        return count;
+    }
+
+    operator T&()
+    {
+        return count;
+    }
+
+private:
+    // one cacheline worth, actual counter
+    alignas(64) T count = 0;
+};
+
+
+using u64_64B = Counter<uint64_t>;
+using i64_64B = Counter<int64_t>;
+using u32_64B = Counter<uint32_t>;
+using i32_64B = Counter<int32_t>;
+
+static_assert(sizeof(u64_64B) == 64);
+static_assert(sizeof(i64_64B) == 64);
+static_assert(sizeof(u32_64B) == 64);
+static_assert(sizeof(i32_64B) == 64);
+
+} // namespace input_osm
+
+#endif // _INPUTOSMTESTCOUNTER_H_

--- a/test/integration/statistics.cpp
+++ b/test/integration/statistics.cpp
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "counter.h"
+
 #include <inputosm/inputosm.h>
 
 #include <iostream>
@@ -36,60 +38,60 @@ int main(int argc, char **argv)
         std::cout << "reading metadata\n";
     input_osm::set_max_thread_count();
     std::cout << "running on " << input_osm::thread_count() << " threads\n";
-    
-    std::vector<uint64_t> node_count(input_osm::thread_count(), 0);
-    std::vector<uint64_t> way_count(input_osm::thread_count(), 0);
-    std::vector<uint64_t> relation_count(input_osm::thread_count(), 0);
 
-    std::vector<uint64_t> max_node_count(input_osm::thread_count(), 0);
-    std::vector<uint64_t> max_node_tag_count(input_osm::thread_count(), 0);
+    std::vector<input_osm::u64_64B> node_count(input_osm::thread_count(), 0);
+    std::vector<input_osm::u64_64B> way_count(input_osm::thread_count(), 0);
+    std::vector<input_osm::u64_64B> relation_count(input_osm::thread_count(), 0);
 
-    std::vector<uint64_t> max_way_count(input_osm::thread_count(), 0);
-    std::vector<uint64_t> max_way_tag_count(input_osm::thread_count(), 0);
-    std::vector<uint64_t> max_way_node_count(input_osm::thread_count(), 0);
+    std::vector<input_osm::u64_64B> max_node_count(input_osm::thread_count(), 0);
+    std::vector<input_osm::u64_64B> max_node_tag_count(input_osm::thread_count(), 0);
 
-    std::vector<uint64_t> max_relation_count(input_osm::thread_count(), 0);
-    std::vector<uint64_t> max_relation_tag_count(input_osm::thread_count(), 0);
-    std::vector<uint64_t> max_relation_member_count(input_osm::thread_count(), 0);
+    std::vector<input_osm::u64_64B> max_way_count(input_osm::thread_count(), 0);
+    std::vector<input_osm::u64_64B> max_way_tag_count(input_osm::thread_count(), 0);
+    std::vector<input_osm::u64_64B> max_way_node_count(input_osm::thread_count(), 0);
 
-    std::vector<int32_t> node_timestamp(input_osm::thread_count(), 0);
-    std::vector<int32_t> way_timestamp(input_osm::thread_count(), 0);
-    std::vector<int32_t> relation_timestamp(input_osm::thread_count(), 0);
+    std::vector<input_osm::u64_64B> max_relation_count(input_osm::thread_count(), 0);
+    std::vector<input_osm::u64_64B> max_relation_tag_count(input_osm::thread_count(), 0);
+    std::vector<input_osm::u64_64B> max_relation_member_count(input_osm::thread_count(), 0);
 
-    std::vector<size_t> block_index(input_osm::thread_count(), 0);
-    
-    std::vector<uint64_t> node_with_tags_count(input_osm::thread_count(), 0);
-    std::vector<uint64_t> ways_with_tags_count(input_osm::thread_count(), 0);
-    std::vector<uint64_t> relations_with_tags_count(input_osm::thread_count(), 0);
+    std::vector<input_osm::i32_64B> node_timestamp(input_osm::thread_count(), 0);
+    std::vector<input_osm::i32_64B> way_timestamp(input_osm::thread_count(), 0);
+    std::vector<input_osm::i32_64B> relation_timestamp(input_osm::thread_count(), 0);
 
-    std::vector<int64_t> max_node_id(input_osm::thread_count(), 0);
-    std::vector<int64_t> max_way_id(input_osm::thread_count(), 0);
-    std::vector<int64_t> max_relation_id(input_osm::thread_count(), 0);
+    std::vector<input_osm::u64_64B> block_index(input_osm::thread_count(), 0);
+
+    std::vector<input_osm::u64_64B> node_with_tags_count(input_osm::thread_count(), 0);
+    std::vector<input_osm::u64_64B> ways_with_tags_count(input_osm::thread_count(), 0);
+    std::vector<input_osm::u64_64B> relations_with_tags_count(input_osm::thread_count(), 0);
+
+    std::vector<input_osm::i64_64B> max_node_id(input_osm::thread_count(), 0);
+    std::vector<input_osm::i64_64B> max_way_id(input_osm::thread_count(), 0);
+    std::vector<input_osm::i64_64B> max_relation_id(input_osm::thread_count(), 0);
 
     if (!input_osm::input_file(
             path,
             read_metadata,
             [&node_count, &max_node_count, &max_node_tag_count, &node_timestamp, &block_index, &node_with_tags_count, &max_node_id]
             (input_osm::span_t<input_osm::node_t> node_list) noexcept -> bool
-            { 
+            {
                 auto cnt = node_list.size();
                 node_count[input_osm::thread_index] += cnt;
                 if(cnt > max_node_count[input_osm::thread_index])
                     max_node_count[input_osm::thread_index] = cnt;
                 cnt = 0;
-                for(auto &n: node_list) 
+                for(auto &n: node_list)
                     cnt += n.tags.size();
                 if(cnt > max_node_tag_count[input_osm::thread_index])
                     max_node_tag_count[input_osm::thread_index] = cnt;
                 for(auto &n: node_list)
-                    node_timestamp[input_osm::thread_index] = std::max(node_timestamp[input_osm::thread_index], n.timestamp);
-                block_index[input_osm::thread_index] = std::max(block_index[input_osm::thread_index], input_osm::block_index);
+                    node_timestamp[input_osm::thread_index] = std::max<int32_t>(node_timestamp[input_osm::thread_index], n.timestamp);
+                block_index[input_osm::thread_index] = std::max<uint64_t>(block_index[input_osm::thread_index], input_osm::block_index);
                 for(auto &n: node_list)
                     if(!n.tags.empty())
                         node_with_tags_count[input_osm::thread_index]++;
                 for(auto &n: node_list)
-                    max_node_id[input_osm::thread_index] = std::max(max_node_id[input_osm::thread_index], n.id);
-                return true; 
+                    max_node_id[input_osm::thread_index] = std::max<int64_t>(max_node_id[input_osm::thread_index], n.id);
+                return true;
             },
             [&way_count, &max_way_count, &max_way_tag_count, &max_way_node_count, &way_timestamp, &block_index, &ways_with_tags_count, &max_way_id]
             (input_osm::span_t<input_osm::way_t> way_list) noexcept -> bool
@@ -109,13 +111,13 @@ int main(int argc, char **argv)
                 if(cnt > max_way_node_count[input_osm::thread_index])
                     max_way_node_count[input_osm::thread_index] = cnt;
                 for(auto &w: way_list)
-                    way_timestamp[input_osm::thread_index] = std::max(way_timestamp[input_osm::thread_index], w.timestamp);
-                block_index[input_osm::thread_index] = std::max(block_index[input_osm::thread_index], input_osm::block_index);
+                    way_timestamp[input_osm::thread_index] = std::max<int32_t>(way_timestamp[input_osm::thread_index], w.timestamp);
+                block_index[input_osm::thread_index] = std::max<uint64_t>(block_index[input_osm::thread_index], input_osm::block_index);
                 for(auto &w: way_list)
                     if(!w.tags.empty())
                         ways_with_tags_count[input_osm::thread_index]++;
                 for(auto &w: way_list)
-                    max_way_id[input_osm::thread_index] = std::max(max_way_id[input_osm::thread_index], w.id);
+                    max_way_id[input_osm::thread_index] = std::max<int64_t>(max_way_id[input_osm::thread_index], w.id);
                 return true;
             },
             [&relation_count, &max_relation_count, &max_relation_tag_count, &max_relation_member_count, &relation_timestamp, &block_index, &relations_with_tags_count, &max_relation_id]
@@ -126,7 +128,7 @@ int main(int argc, char **argv)
                 if(cnt > max_relation_count[input_osm::thread_index])
                     max_relation_count[input_osm::thread_index] = cnt;
                 cnt = 0;
-                for(auto &r: relation_list) 
+                for(auto &r: relation_list)
                     cnt += r.tags.size();
                 if(cnt > max_relation_tag_count[input_osm::thread_index])
                     max_relation_tag_count[input_osm::thread_index] = cnt;
@@ -136,13 +138,13 @@ int main(int argc, char **argv)
                 if(cnt > max_relation_member_count[input_osm::thread_index])
                     max_relation_member_count[input_osm::thread_index] = cnt;
                 for(auto &r: relation_list)
-                    relation_timestamp[input_osm::thread_index] = std::max(relation_timestamp[input_osm::thread_index], r.timestamp);
-                block_index[input_osm::thread_index] = std::max(block_index[input_osm::thread_index], input_osm::block_index);
+                    relation_timestamp[input_osm::thread_index] = std::max<int32_t>(relation_timestamp[input_osm::thread_index], r.timestamp);
+                block_index[input_osm::thread_index] = std::max<uint64_t>(block_index[input_osm::thread_index], input_osm::block_index);
                 for(auto &r: relation_list)
                     if(!r.tags.empty())
                         relations_with_tags_count[input_osm::thread_index]++;
                 for(auto &r: relation_list)
-                    max_relation_id[input_osm::thread_index] = std::max(max_relation_id[input_osm::thread_index], r.id);
+                    max_relation_id[input_osm::thread_index] = std::max<int64_t>(max_relation_id[input_osm::thread_index], r.id);
                 return true;
             }))
     {


### PR DESCRIPTION
add a simple counter that aligns on 64B (size of a chache line) use that instead of having 8 B uint64s consecutive and touched by different threads
the impact is larger if the processing itself is fast, otherwise the bottleneck is somewhere else, still, not invalidating cache lines is nice