### PR TITLE
Timestamp parsing functions fix

### DIFF
--- a/src/timeutil.cpp
+++ b/src/timeutil.cpp
@@ -13,7 +13,8 @@
 
 #include "timeutil.h"
 #include <chrono>
-#include <inttypes.h>
+#include <ctime>
+#include <cinttypes>
 
 int64_t now_ms()
 {
@@ -29,16 +30,24 @@ int64_t now_us()
 
 time_t str_to_timestamp(const char* str)
 {
-    struct tm timeinfo;
-    strptime(str, "%FT%TZ", &timeinfo);
-    return mktime(&timeinfo);
+    struct tm timeinfo{};
+    if (strptime(str, "%FT%TZ", &timeinfo) == nullptr)
+    {
+        return 0;
+    }
+    return timegm(&timeinfo);
 }
+
 time_t str_to_timestamp_osmstate(const char* str)
 {
-    struct tm timeinfo;
-    strptime(str, "%FT%H\\:%M\\:%SZ", &timeinfo);
-    return mktime(&timeinfo);
+    struct tm timeinfo{};
+    if (strptime(str, "%FT%H\\:%M\\:%SZ", &timeinfo) == nullptr)
+    {
+        return 0;
+    }
+    return timegm(&timeinfo);
 }
+
 std::string timestamp_to_str(const time_t rawtime)
 {
     struct tm* dt;


### PR DESCRIPTION
Refactor timestamp parsing functions to handle errors and use `timegm` for UTC conversion

---

This pull request updates the `src/timeutil.cpp` file to improve time parsing reliability and portability. The main changes include switching to C++ standard headers and making the string-to-timestamp conversion functions more robust by handling parsing failures and using UTC time conversion.

Header improvements:

* Replaced the C-style `#include <inttypes.h>` with the C++ standard headers `#include <ctime>` and `#include <cinttypes>` for better portability and standards compliance.

Time parsing robustness:

* Updated `str_to_timestamp` and `str_to_timestamp_osmstate` to:
  - Zero-initialize the `struct tm` before use.
  - Check the result of `strptime` and return 0 if parsing fails, preventing undefined behavior.
  - Use `timegm` instead of `mktime` to ensure timestamps are interpreted as UTC rather than local time.